### PR TITLE
Add special logic for Conversations SDK

### DIFF
--- a/bin/strip-private-prefix
+++ b/bin/strip-private-prefix
@@ -1,23 +1,48 @@
 #!/bin/sh
 set -e
 
-if [ $# -eq 0 ]; then
-    echo "No arguments provided"
-    exit 1
-fi
+unset IS_CONVO
+unset PREFIX
 
-export PREFIX=$(echo $1 | perl -p -e "s/@/\\\@/g")
+for arg in "$@"; do
+  case $arg in
+    --conversations)
+      export IS_CONVO=true
+      ;;
+    -*)
+      echo "Invalid flag $arg was provided"
+      exit 1
+      ;;
+    *)
+      if [ -z ${PREFIX+x} ]; then
+        export PREFIX=$(echo $arg | perl -p -e "s/@/\\\@/g")
+      else
+        echo "Invalid argument $arg was provided"
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+if [ -z ${PREFIX+x} ]; then
+  echo "No prefix provided"
+  exit 1
+fi
 
 echo -n "Stripping private repo prefix '$PREFIX' from package.json and source files .. "
 
 if [ -d "test" ]; then
-    find ./test -name "*.ts" -exec perl -pi -e "s/(import.*)$PREFIX\/(.*)/\$1\$2/" {} \;
+  find ./test -name "*.ts" -exec perl -pi -e "s/(import.*)$PREFIX\/(.*)/\$1\$2/" {} \;
 fi
 
 if [ -d "src" ]; then
-    find ./src -name "*.ts" -exec perl -pi -e "s/(import.*)$PREFIX\/(.*)/\$1\$2/" {} \;
+  find ./src -name "*.ts" -exec perl -pi -e "s/(import.*)$PREFIX\/(.*)/\$1\$2/" {} \;
 fi
 
 perl -pi -e "s/(.*)$PREFIX\/(.*)/\$1\$2/" package.json
 
-echo "done";
+if [ $IS_CONVO ]; then
+  perl -pi -e "s/(.*\"name\": \").*(\".*)/\$1$PREFIX\/conversations\$2/" package.json
+fi
+
+echo "Done";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "circleci-build-publisher",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circleci-build-publisher",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Tools to prepare Twilio JS projects for npm publishing.",
   "author": "Sergei Chertkov",
   "contributors": [


### PR DESCRIPTION
This PR adds a special flag for Conversations SDK, which makes it so that `@twilio/twilio-conversations` will get renamed to `@twilio/conversations` for public release.

The same change was done for `rtd-travis-build-publisher`: https://github.com/twilio/rtd-travis-build-publisher/commit/d6b185fa2ad577ad03a46fd231750a833485b26a